### PR TITLE
Support legacy transaction spec test format

### DIFF
--- a/src/Command/ConvertSpecTestCommand.php
+++ b/src/Command/ConvertSpecTestCommand.php
@@ -30,7 +30,7 @@ class ConvertSpecTestCommand extends Command
 
         $this
             ->addArgument('suite', InputArgument::REQUIRED, 'Test suite to convert')
-            ->addArgument('mask', InputArgument::OPTIONAL, 'Optional file mask for tests', '**.yml')
+            ->addArgument('mask', InputArgument::OPTIONAL, 'Optional file mask for tests')
         ;
     }
 
@@ -44,7 +44,7 @@ class ConvertSpecTestCommand extends Command
 
         $converter = self::SUITES[$suite];
 
-        (new SpecTestToUnifiedConverter($converter))->convert();
+        (new SpecTestToUnifiedConverter($converter))->convert($input->getArgument('mask'));
 
         return Command::SUCCESS;
     }

--- a/src/Command/ConvertSpecTestCommand.php
+++ b/src/Command/ConvertSpecTestCommand.php
@@ -5,6 +5,7 @@ namespace App\Command;
 use App\Converter\Crud\V2\CrudV2SuiteConverter;
 use App\Converter\SpecTestToUnifiedConverter;
 use App\Converter\TestSuiteConverterInterface;
+use App\Converter\Transactions\TransactionsSuiteConverter;
 use LogicException;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
@@ -20,6 +21,7 @@ class ConvertSpecTestCommand extends Command
 {
     private const SUITES = [
         'crud-v2' => CrudV2SuiteConverter::class,
+        'transactions' => TransactionsSuiteConverter::class,
     ];
 
     protected function configure()

--- a/src/Converter/Crud/V2/CrudV2RootConverter.php
+++ b/src/Converter/Crud/V2/CrudV2RootConverter.php
@@ -8,7 +8,7 @@ use function basename;
 
 final class CrudV2RootConverter implements RootConverterInterface
 {
-    public function convert(string $filename, array $inputData): array
+    public function convert(string $filename, object $inputData): array
     {
         return [
             'description' => basename($filename, '.yml'),
@@ -22,12 +22,12 @@ final class CrudV2RootConverter implements RootConverterInterface
                 ['database' => [
                     'id' => new Anchor('database0', 'database0'),
                     'client' => 'client0',
-                    'databaseName' => $inputData['database_name'] ?? new Anchor('database_name', 'crud-v2'),
+                    'databaseName' => $inputData->database_name ?? new Anchor('database_name', 'crud-v2'),
                 ]],
                 ['collection' => [
                     'id' => new Anchor('collection0', 'collection0'),
                     'database' => 'database0',
-                    'collectionName' => $inputData['collection_name'] ?? new Anchor('collection_name', 'crud-v2'),
+                    'collectionName' => $inputData->collection_name ?? new Anchor('collection_name', 'crud-v2'),
                 ]],
             ],
             'initialData' => [],

--- a/src/Converter/Crud/V2/CrudV2RootConverter.php
+++ b/src/Converter/Crud/V2/CrudV2RootConverter.php
@@ -13,11 +13,10 @@ final class CrudV2RootConverter implements RootConverterInterface
         return [
             'description' => basename($filename, '.yml'),
             'schemaVersion' => '1.1',
+            'runOnRequirements' => [],
             'createEntities' => [
                 ['client' => [
                     'id' => new Anchor('client0', 'client0'),
-                    'useMultipleMongoses' => false,
-                    'uriOptions' => ['retryReads' => false],
                     'observeEvents' => ['commandStartedEvent'],
                 ]],
                 ['database' => [
@@ -30,7 +29,9 @@ final class CrudV2RootConverter implements RootConverterInterface
                     'database' => 'database0',
                     'collectionName' => $inputData['collection_name'] ?? new Anchor('collection_name', 'crud-v2'),
                 ]],
-            ]
+            ],
+            'initialData' => [],
+            'tests' => [],
         ];
     }
 }

--- a/src/Converter/Crud/V2/CrudV2TestConverter.php
+++ b/src/Converter/Crud/V2/CrudV2TestConverter.php
@@ -16,10 +16,10 @@ final class CrudV2TestConverter implements TestItemConverterInterface
     public function convert(string $fieldName, mixed $data): mixed
     {
         if (isset($data['failPoint'])) {
-            array_unshift($data['operations'], [
+            array_unshift($data['operations'], (object) [
                 'name' => 'failPoint',
                 'object' => 'testRunner',
-                'arguments' => [
+                'arguments' => (object) [
                     'client' => new Reference('client0'),
                     'failPoint' => $data['failPoint'],
                 ],

--- a/src/Converter/ListConverter.php
+++ b/src/Converter/ListConverter.php
@@ -2,17 +2,17 @@
 
 namespace App\Converter;
 
-final class ListConverter implements TestItemConverterInterface
+final class ListConverter extends YamlAnchorAwareConverter
 {
     public function __construct(
         private TestItemConverterInterface $converter,
         private bool $useFieldName = false,
     ) {}
 
-    public function convert(string $fieldName, mixed $data): mixed
+    protected function doConvert(string $fieldName, mixed $data): mixed
     {
         $converted = array_map(
-            fn(mixed $item) => $this->converter->convert($fieldName, $item),
+            fn (mixed $item) => $this->converter->convert($fieldName, $item),
             $data,
         );
 

--- a/src/Converter/Operation/LegacyOperationConverter.php
+++ b/src/Converter/Operation/LegacyOperationConverter.php
@@ -64,10 +64,14 @@ final class LegacyOperationConverter extends YamlAnchorAwareConverter
         ];
 
         if (isset($data->error) && $data->error === true) {
-            $unifiedOperation['expectError'] = ['isError' => $data->error];
-            if (isset($data->result) && is_array($data->result)) {
-                $unifiedOperation['expectError'] += $data->result;
-            }
+            $unifiedOperation['expectError'] = ['isError' => true];
+        }
+
+        // Extract error fields from result
+        if (isset($data->result->errorContains) || isset($data->result->errorCodeName) || isset($data->result->errorLabelsContain) ||isset($data->result->errorLabelsOmit)) {
+            $unifiedOperation['expectError'] ??= [];
+            $unifiedOperation['expectError'] += (array) $data->result;
+            unset($data->result);
         }
 
         if (isset($data->result)) {

--- a/src/Converter/Operation/LegacyOperationConverter.php
+++ b/src/Converter/Operation/LegacyOperationConverter.php
@@ -22,52 +22,52 @@ final class LegacyOperationConverter extends YamlAnchorAwareConverter
             return null;
         }
 
-        if ($data['name'] === 'bulkWrite') {
-            $data['arguments']['requests'] = array_map(
+        if ($data->name === 'bulkWrite') {
+            $data->arguments->requests = array_map(
                 fn ($request) => [
-                    $request['name'] => $request['arguments'],
+                    $request->name => $request->arguments,
                 ],
-                $data['arguments']['requests'],
+                $data->arguments->requests,
             );
         }
 
-        if ($data['name'] === 'runCommand' && isset($data['command_name'])) {
-            $data['arguments']['commandName'] = $data['command_name'];
-            unset($data['command_name']);
+        if ($data->name === 'runCommand' && isset($data->command_name)) {
+            $data->arguments->commandName = $data->command_name;
+            unset($data->command_name);
         }
 
-        if (isset($data['arguments']) && is_array($data['arguments'])) {
-            if (isset($data['arguments']['options'])) {
-                $options = $data['arguments']['options'];
-                unset($data['arguments']['options']);
-                $data['arguments'] = array_merge($data['arguments'], $options);
+        if (isset($data->arguments) && is_object($data->arguments)) {
+            if (isset($data->arguments->options)) {
+                $options = $data->arguments->options;
+                unset($data->arguments->options);
+                $data->arguments = (object) array_merge((array) $data->arguments, (array) $options);
             }
 
-            if (isset($data['arguments']['session']) && !$data['arguments']['session'] instanceof Reference) {
-                $data['arguments']['session'] = new Reference($data['arguments']['session']);
+            if (isset($data->arguments->session) && !$data->arguments->session instanceof Reference) {
+                $data->arguments->session = new Reference($data->arguments->session);
             }
         }
 
         $unifiedOperation = [
-            'object' => $this->getOperationObject($data['object'] ?? 'collection'),
+            'object' => $this->getOperationObject($data->object ?? 'collection'),
             // databaseOptions not supported, will cause validation errors to point out manual work
-            'databaseOptions' => $data['databaseOptions'] ?? null,
+            'databaseOptions' => $data->databaseOptions ?? null,
             // collectionOptions not supported, will cause validation errors to point out manual work
-            'collectionOptions' => $data['collectionOptions'] ?? null,
-            'name' => $data['name'],
-            'arguments' => $data['arguments'] ?? null,
-            'command_name' => $data['command_name'] ?? null,
+            'collectionOptions' => $data->collectionOptions ?? null,
+            'name' => $data->name,
+            'arguments' => $data->arguments ?? null,
+            'command_name' => $data->command_name ?? null,
             // error handled below
             // result handled below
         ];
 
-        if (isset($data['error']) && $data['error'] === true) {
-            $unifiedOperation['expectError'] = ['isError' => $data['error']];
-            if (isset($data['result']) && is_array($data['result'])) {
-                $unifiedOperation['expectError'] += $data['result'];
+        if (isset($data->error) && $data->error === true) {
+            $unifiedOperation['expectError'] = ['isError' => $data->error];
+            if (isset($data->result) && is_array($data->result)) {
+                $unifiedOperation['expectError'] += $data->result;
             }
-        } elseif (isset($data['result'])) {
-            $unifiedOperation['expectResult'] = $data['result'];
+        } elseif (isset($data->result)) {
+            $unifiedOperation['expectResult'] = $data->result;
         }
 
         return array_filter_null($unifiedOperation);

--- a/src/Converter/RootConverterInterface.php
+++ b/src/Converter/RootConverterInterface.php
@@ -4,5 +4,5 @@ namespace App\Converter;
 
 interface RootConverterInterface
 {
-    public function convert(string $filename, array $inputData): array;
+    public function convert(string $filename, object $inputData): array;
 }

--- a/src/Converter/RunOnRequirementConverter.php
+++ b/src/Converter/RunOnRequirementConverter.php
@@ -13,9 +13,9 @@ final class RunOnRequirementConverter implements TestItemConverterInterface
         return [
             'runOnRequirements' => array_map(
                 static function ($runOnRequirement) {
-                    if (isset($runOnRequirement['topology'])) {
-                        $runOnRequirement['topologies'] = $runOnRequirement['topology'];
-                        unset($runOnRequirement['topology']);
+                    if (isset($runOnRequirement->topology)) {
+                        $runOnRequirement->topologies = $runOnRequirement->topology;
+                        unset($runOnRequirement->topology);
                     }
 
                     return $runOnRequirement;

--- a/src/Converter/SpecTestToUnifiedConverter.php
+++ b/src/Converter/SpecTestToUnifiedConverter.php
@@ -54,6 +54,10 @@ class SpecTestToUnifiedConverter
         }
 
         $outputData = $this->applyItemConverters($inputData, $initialOutputData);
+        $outputData = array_filter(
+            $outputData,
+            fn ($input): bool  => $input !== [],
+        );
 
         $yaml = Yaml::dump($outputData, 12, 2, Yaml::DUMP_EMPTY_ARRAY_AS_SEQUENCE | Yaml::DUMP_OBJECT_AS_MAP);
         $yaml = <<<YAML

--- a/src/Converter/SpecTestToUnifiedConverter.php
+++ b/src/Converter/SpecTestToUnifiedConverter.php
@@ -4,6 +4,7 @@ namespace App\Converter;
 
 use InvalidArgumentException;
 use RuntimeException;
+use stdClass;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Finder\SplFileInfo;
@@ -25,14 +26,14 @@ class SpecTestToUnifiedConverter
         }
     }
 
-    public function convert(): void
+    public function convert(?string $mask = null): void
     {
         $baseDir = ($this->converter)::getInputDir();
         $finder = new Finder();
         $finder
             ->files()
             ->in($baseDir)
-            ->name(($this->converter)::getMask());
+            ->name($mask ?? ($this->converter)::getMask());
 
         foreach ($finder as $file) {
             $this->convertFile($file);
@@ -70,7 +71,7 @@ YAML;
         (new Filesystem())->dumpFile($output, $yaml);
     }
 
-    private function applyItemConverters(array $inputData, array $initialOutputData = []): array
+    private function applyItemConverters(stdClass $inputData, array $initialOutputData = []): array
     {
         $outputData = $initialOutputData;
 
@@ -86,7 +87,7 @@ YAML;
                 ));
             }
 
-            $convertedData = $converter->convert($fieldName, $inputData[$fieldName] ?? null);
+            $convertedData = $converter->convert($fieldName, $inputData->$fieldName ?? null);
             if ($convertedData === null) {
                 continue;
             }

--- a/src/Converter/Tests/ExpectationConverter.php
+++ b/src/Converter/Tests/ExpectationConverter.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace App\Converter\Tests;
+
+use App\Converter\YamlAnchorAwareConverter;
+use Symfony\Component\Yaml\Reference\Reference;
+use function App\array_map_recursive;
+use function array_filter;
+use function array_keys;
+use function array_map;
+use function current;
+use function key;
+use function reset;
+
+final class ExpectationConverter extends YamlAnchorAwareConverter
+{
+    private const DEFAULT_UPDATE_CMD_OPTIONS = [
+        'multi' => ['$$unsetOrMatches' => false],
+        'upsert' => ['$$unsetOrMatches' => false],
+    ];
+
+    private const EVENT_NAME_MAP = [
+        'command_started_event' => 'commandStartedEvent',
+    ];
+
+    protected function doConvert(string $fieldName, mixed $data): ?array
+    {
+        if (!is_array($data)) {
+            return $data;
+        }
+
+        reset($data);
+        $event = key($data);
+        $eventData = current($data);
+
+        return [self::EVENT_NAME_MAP[$event] ?? $event => array_filter([
+            'command' => $this->convertCommandExpectations($eventData['command']),
+            'commandName' => $eventData['command_name'] ?? false,
+            'databaseName' => $eventData['database_name'] ?? false,
+        ])];
+    }
+
+    private function convertCommandExpectations(array $command): array
+    {
+        $command = $this->addMissingUpdateCommandOptions($command);
+        $command = $this->replaceSessionIdCheck($command);
+        $command = $this->replaceMagicNumberExpectations($command);
+        return $this->convertExpectedNullValues($command);
+    }
+
+    private function addMissingUpdateCommandOptions(array $command): array
+    {
+        $commandName = array_keys($command)[0];
+        if ($commandName !== 'update') {
+            return $command;
+        }
+
+        $command['updates'] = array_map(
+            fn (array $update): array => $update + self::DEFAULT_UPDATE_CMD_OPTIONS,
+            $command['updates'],
+        );
+
+        return $command;
+    }
+
+    private function replaceSessionIdCheck(array $command): array
+    {
+        if (isset($command['lsid'])) {
+            $command['lsid'] = ['$$sessionLsid' => new Reference($command['lsid'])];
+        }
+
+        return $command;
+    }
+
+    private function replaceMagicNumberExpectations(array $command): array
+    {
+        if (isset($command['getMore'])) {
+            $command['getMore'] = ['$$type' => 'long'];
+        }
+
+        if (isset($command['readConcern']['afterClusterTime']) && $command['readConcern']['afterClusterTime'] === 42) {
+            $command['readConcern']['afterClusterTime'] = ['$$exists' => true];
+        }
+
+        if (isset($command['recoveryToken']) && $command['recoveryToken'] === 42) {
+            $command['recoveryToken'] = ['$$exists' => true];
+        }
+
+        return $command;
+    }
+
+    private function convertExpectedNullValues(array $array): array
+    {
+        return array_map_recursive(
+            fn ($value) => $value !== null ? $value : ['$$exists' => false],
+            $array,
+        );
+    }
+}

--- a/src/Converter/Tests/ExpectationConverter.php
+++ b/src/Converter/Tests/ExpectationConverter.php
@@ -80,7 +80,7 @@ final class ExpectationConverter extends YamlAnchorAwareConverter
     private function replaceMagicNumberExpectations(array $command): array
     {
         if (isset($command['getMore'])) {
-            $command['getMore'] = ['$$type' => 'long'];
+            $command['getMore'] = ['$$type' => ['int', 'long']];
         }
 
         if (isset($command['readConcern']->afterClusterTime) && $command['readConcern']->afterClusterTime === 42) {

--- a/src/Converter/Tests/ExpectationsConverter.php
+++ b/src/Converter/Tests/ExpectationsConverter.php
@@ -2,25 +2,13 @@
 
 namespace App\Converter\Tests;
 
-use App\Converter\TestItemConverterInterface;
+use App\Converter\ListConverter;
+use App\Converter\YamlAnchorAwareConverter;
 use Symfony\Component\Yaml\Reference\Reference;
-use function App\array_map_recursive;
-use function array_filter;
-use function array_keys;
-use function array_map;
 
-final class ExpectationsConverter implements TestItemConverterInterface
+final class ExpectationsConverter extends YamlAnchorAwareConverter
 {
-    private const DEFAULT_UPDATE_CMD_OPTIONS = [
-        'multi' => ['$$unsetOrMatches' => false],
-        'upsert' => ['$$unsetOrMatches' => false],
-    ];
-
-    private const EVENT_NAME_MAP = [
-        'command_started_event' => 'commandStartedEvent',
-    ];
-
-    public function convert(string $fieldName, mixed $data): ?array
+    protected function doConvert(string $fieldName, mixed $data): ?array
     {
         if ($data === null) {
             return null;
@@ -28,49 +16,8 @@ final class ExpectationsConverter implements TestItemConverterInterface
 
         return [[
             'client' => new Reference('client0'),
-            'events' => array_map(
-                function (array $expectation): array {
-                    reset($expectation);
-                    $event = key($expectation);
-                    $eventData = current($expectation);
-
-                    return [self::EVENT_NAME_MAP[$event] ?? $event => array_filter([
-                        'command' => $this->convertCommandExpectations($eventData['command']),
-                        'commandName' => $eventData['command_name'] ?? false,
-                        'databaseName' => $eventData['database_name'] ?? false,
-                    ])];
-                },
-                $data,
-            ),
+            'events' => (new ListConverter(new ExpectationConverter(), false))
+                ->convert('', $data),
         ]];
-    }
-
-    private function convertCommandExpectations(array $command): array
-    {
-        $command = $this->addMissingUpdateCommandOptions($command);
-        return $this->convertExpectedNullValues($command);
-    }
-
-    private function addMissingUpdateCommandOptions(array $command): array
-    {
-        $commandName = array_keys($command)[0];
-        if ($commandName !== 'update') {
-            return $command;
-        }
-
-        $command['updates'] = array_map(
-            fn (array $update): array => $update + self::DEFAULT_UPDATE_CMD_OPTIONS,
-            $command['updates'],
-        );
-
-        return $command;
-    }
-
-    private function convertExpectedNullValues(array $array): array
-    {
-        return array_map_recursive(
-            fn ($value) => $value !== null ? $value : ['$$exists' => false],
-            $array,
-        );
     }
 }

--- a/src/Converter/Tests/OutcomeConverter.php
+++ b/src/Converter/Tests/OutcomeConverter.php
@@ -20,9 +20,9 @@ class OutcomeConverter implements TestItemConverterInterface
         }
 
         $result = [[
-            'collectionName' => $data['collection']['name'] ?? new Reference('collection_name'),
+            'collectionName' => $data->collection->name ?? new Reference('collection_name'),
             'databaseName' => new Reference('database_name'),
-            'documents' => $data['collection']['data'],
+            'documents' => $data->collection->data,
         ]];
 
         return isset($anchorName) ? new Anchor($anchorName, $result) : $result;

--- a/src/Converter/Transactions/TransactionsRootConverter.php
+++ b/src/Converter/Transactions/TransactionsRootConverter.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Converter\Transactions;
+
+use App\Converter\RootConverterInterface;
+use Symfony\Component\Yaml\Reference\Anchor;
+use Symfony\Component\Yaml\Reference\Reference;
+use function basename;
+
+final class TransactionsRootConverter implements RootConverterInterface
+{
+    public function convert(string $filename, array $inputData): array
+    {
+        return [
+            'description' => basename($filename, '.yml'),
+            'schemaVersion' => '1.1',
+            'createEntities' => [
+                ['client' => [
+                    'id' => new Anchor('client0', 'client0'),
+                    'useMultipleMongoses' => false,
+                    'observeEvents' => ['commandStartedEvent'],
+                ]],
+                ['database' => [
+                    'id' => new Anchor('database0', 'database0'),
+                    'client' => new Reference('client0'),
+                    'databaseName' => $inputData['database_name'] ?? new Anchor('database_name', 'transactions'),
+                ]],
+                ['collection' => [
+                    'id' => new Anchor('collection0', 'collection0'),
+                    'database' => new Reference('database0'),
+                    'collectionName' => $inputData['collection_name'] ?? new Anchor('collection_name', 'transactions'),
+                ]],
+                ['session' => [
+                    'id' => new Anchor('session0', 'session0'),
+                    'client' => new Reference('client0'),
+                ]],
+                ['session' => [
+                    'id' => new Anchor('session1', 'session1'),
+                    'client' => new Reference('client0'),
+                ]],
+            ]
+        ];
+    }
+}

--- a/src/Converter/Transactions/TransactionsRootConverter.php
+++ b/src/Converter/Transactions/TransactionsRootConverter.php
@@ -9,11 +9,11 @@ use function basename;
 
 final class TransactionsRootConverter implements RootConverterInterface
 {
-    public function convert(string $filename, array $inputData): array
+    public function convert(string $filename, object $inputData): array
     {
         return [
             'description' => basename($filename, '.yml'),
-            'schemaVersion' => '1.1',
+            'schemaVersion' => '1.3',
             'createEntities' => [
                 ['client' => [
                     'id' => new Anchor('client0', 'client0'),
@@ -23,12 +23,12 @@ final class TransactionsRootConverter implements RootConverterInterface
                 ['database' => [
                     'id' => new Anchor('database0', 'database0'),
                     'client' => new Reference('client0'),
-                    'databaseName' => $inputData['database_name'] ?? new Anchor('database_name', 'transactions'),
+                    'databaseName' => $inputData->database_name ?? new Anchor('database_name', 'transactions'),
                 ]],
                 ['collection' => [
                     'id' => new Anchor('collection0', 'collection0'),
                     'database' => new Reference('database0'),
-                    'collectionName' => $inputData['collection_name'] ?? new Anchor('collection_name', 'transactions'),
+                    'collectionName' => $inputData->collection_name ?? new Anchor('collection_name', 'transactions'),
                 ]],
                 ['session' => [
                     'id' => new Anchor('session0', 'session0'),

--- a/src/Converter/Transactions/TransactionsRootConverter.php
+++ b/src/Converter/Transactions/TransactionsRootConverter.php
@@ -13,6 +13,7 @@ final class TransactionsRootConverter implements RootConverterInterface
     {
         return [
             'description' => basename($filename, '.yml'),
+            // 1.3 is required because of load-balanced topologies
             'schemaVersion' => '1.3',
             'createEntities' => [
                 ['client' => [

--- a/src/Converter/Transactions/TransactionsSuiteConverter.php
+++ b/src/Converter/Transactions/TransactionsSuiteConverter.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Converter\Transactions;
+
+use App\Converter\InitialDataConverter;
+use App\Converter\ListConverter;
+use App\Converter\RootConverterInterface;
+use App\Converter\RunOnRequirementConverter;
+use App\Converter\TestSuiteConverterInterface;
+
+final class TransactionsSuiteConverter implements TestSuiteConverterInterface
+{
+    public static function getInputDir(): string
+    {
+        return __DIR__ . '/../../../spec/source/transactions/tests/legacy';
+    }
+
+    public static function getOutputDir(): string
+    {
+        return __DIR__ . '/../../../spec/source/transactions/tests/unified/';
+    }
+
+    public static function getMask(): string
+    {
+        return '*.yml';
+    }
+
+    public static function getRootConverter(): ?RootConverterInterface
+    {
+        return new TransactionsRootConverter();
+    }
+
+    public static function getItemConverters(): array
+    {
+        return [
+            'runOn' => new RunOnRequirementConverter(),
+            // collection_name handled in root converter
+            // database_name handled in root converter
+            'data' => new InitialDataConverter(),
+            'tests' => new ListConverter(new TransactionsTestConverter(), true),
+        ];
+    }
+}

--- a/src/Converter/Transactions/TransactionsTestConverter.php
+++ b/src/Converter/Transactions/TransactionsTestConverter.php
@@ -16,36 +16,36 @@ final class TransactionsTestConverter implements TestItemConverterInterface
 {
     public function convert(string $fieldName, mixed $data): mixed
     {
-        if (isset($data['failPoint'])) {
-            array_unshift($data['operations'], [
+        if (isset($data->failPoint)) {
+            array_unshift($data->operations, (object) [
                 'name' => 'failPoint',
                 'object' => 'testRunner',
-                'arguments' => [
+                'arguments' => (object) [
                     'client' => new Reference('client0'),
-                    'failPoint' => $data['failPoint'],
+                    'failPoint' => $data->failPoint,
                 ],
             ]);
         }
 
         $operations = (new ListConverter(new LegacyOperationConverter(), false))
-            ->convert('', $data['operations']);
+            ->convert('', $data->operations);
 
         $expectations = (new ExpectationsConverter())
-            ->convert('', $data['expectations'] ?? null);
+            ->convert('', $data->expectations ?? null);
 
         $outcome = (new OutcomeConverter())
-            ->convert('', $data['outcome'] ?? null);
+            ->convert('', $data->outcome ?? null);
 
         return array_filter_null([
-            'description' => $data['description'],
-            'skipReason' => $data['skipReason'] ?? null,
+            'description' => $data->description,
+            'skipReason' => $data->skipReason ?? null,
             // useMultipleMongoses not supported, will cause errors to point out manual work
-            'useMultipleMongoses' => $data['useMultipleMongoses'] ?? null,
+            'useMultipleMongoses' => $data->useMultipleMongoses ?? null,
             // failPoint handled above
             // clientOptions not supported, will cause errors to point out manual work
-            'clientOptions' => $data['clientOptions'] ?? null,
+            'clientOptions' => $data->clientOptions ?? null,
             // clientOptions not supported, will cause errors to point out manual work
-            'sessionOptions' => $data['sessionOptions'] ?? null,
+            'sessionOptions' => $data->sessionOptions ?? null,
             'operations' => $operations,
             'expectEvents' => $expectations,
             'outcome' => $outcome,

--- a/src/Converter/Transactions/TransactionsTestConverter.php
+++ b/src/Converter/Transactions/TransactionsTestConverter.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Converter\Transactions;
+
+use App\Converter\ListConverter;
+use App\Converter\Operation\LegacyOperationConverter;
+use App\Converter\TestItemConverterInterface;
+use App\Converter\Tests\ExpectationsConverter;
+use App\Converter\Tests\OutcomeConverter;
+use App\Converter\YamlAnchorAwareConverter;
+use Symfony\Component\Yaml\Reference\Reference;
+use function App\array_filter_null;
+use function array_unshift;
+
+final class TransactionsTestConverter implements TestItemConverterInterface
+{
+    public function convert(string $fieldName, mixed $data): mixed
+    {
+        if (isset($data['failPoint'])) {
+            array_unshift($data['operations'], [
+                'name' => 'failPoint',
+                'object' => 'testRunner',
+                'arguments' => [
+                    'client' => new Reference('client0'),
+                    'failPoint' => $data['failPoint'],
+                ],
+            ]);
+        }
+
+        $operations = (new ListConverter(new LegacyOperationConverter(), false))
+            ->convert('', $data['operations']);
+
+        $expectations = (new ExpectationsConverter())
+            ->convert('', $data['expectations'] ?? null);
+
+        $outcome = (new OutcomeConverter())
+            ->convert('', $data['outcome'] ?? null);
+
+        return array_filter_null([
+            'description' => $data['description'],
+            'skipReason' => $data['skipReason'] ?? null,
+            // useMultipleMongoses not supported, will cause errors to point out manual work
+            'useMultipleMongoses' => $data['useMultipleMongoses'] ?? null,
+            // failPoint handled above
+            // clientOptions not supported, will cause errors to point out manual work
+            'clientOptions' => $data['clientOptions'] ?? null,
+            // clientOptions not supported, will cause errors to point out manual work
+            'sessionOptions' => $data['sessionOptions'] ?? null,
+            'operations' => $operations,
+            'expectEvents' => $expectations,
+            'outcome' => $outcome,
+        ]);
+    }
+}

--- a/src/Converter/YamlAnchorAwareConverter.php
+++ b/src/Converter/YamlAnchorAwareConverter.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Converter;
+
+use Symfony\Component\Yaml\Reference\Anchor;
+use Symfony\Component\Yaml\Reference\Reference;
+
+abstract class YamlAnchorAwareConverter implements TestItemConverterInterface
+{
+    final public function convert(string $fieldName, mixed $data): mixed
+    {
+        if ($data instanceof Reference) {
+            return $data;
+        }
+
+        if ($data instanceof Anchor) {
+            $anchorName = $data->getName();
+            $data = $data->getValue();
+        }
+
+        $result = $this->doConvert($fieldName, $data);
+
+        return isset($anchorName) ? new Anchor($anchorName, $result) : $result;
+    }
+
+    abstract protected function doConvert(string $fieldName, mixed $data): mixed;
+}


### PR DESCRIPTION
Note: this doesn't support `withTransaction`. I gave up using the tool for those tests and ported the tests manually.